### PR TITLE
Guess the command handler name automatically

### DIFF
--- a/src/Container/SimpleCommandBusFactory.php
+++ b/src/Container/SimpleCommandBusFactory.php
@@ -3,15 +3,12 @@
 namespace ZfrCommandBus\Container;
 
 use Interop\Container\ContainerInterface;
-use ZfrCommandBus\Exception\OutOfBoundsException;
 use ZfrCommandBus\SimpleCommandBus;
 
 class SimpleCommandBusFactory
 {
     /**
      * @param ContainerInterface $container
-     *
-     * @throws OutOfBoundsException
      *
      * @return SimpleCommandBus
      */
@@ -20,10 +17,6 @@ class SimpleCommandBusFactory
         /** @var array $config */
         $config = $container->get('config');
 
-        if (!isset($config['zfr_command_bus']['command_handlers'])) {
-            throw new OutOfBoundsException('Missing config key [\'zfr_command_bus\'][\'command_handlers\']');
-        }
-
-        return new SimpleCommandBus($container, $config['zfr_command_bus']['command_handlers']);
+        return new SimpleCommandBus($container, $config['zfr_command_bus']['command_handlers'] ?? []);
     }
 }

--- a/src/SimpleCommandBus.php
+++ b/src/SimpleCommandBus.php
@@ -22,7 +22,7 @@ class SimpleCommandBus implements CommandBusInterface
      * @param ContainerInterface $container
      * @param array              $commandMap
      */
-    public function __construct(ContainerInterface $container, array $commandMap)
+    public function __construct(ContainerInterface $container, array $commandMap = [])
     {
         $this->container  = $container;
         $this->commandMap = $commandMap;
@@ -42,17 +42,9 @@ class SimpleCommandBus implements CommandBusInterface
             ));
         }
 
-        $commandClass = get_class($command);
-
-        if (!isset($this->commandMap[$commandClass])) {
-            throw new RuntimeException(sprintf(
-                'No command handler was registered for "%s"',
-                $commandClass
-            ));
-        }
-
-        /** @var callable $commandHandler */
-        $commandHandler = $this->container->get($this->commandMap[$commandClass]);
+        $commandClass       = get_class($command);
+        $commandHandlerName = $this->commandMap[$commandClass] ?? "{$commandClass}Handler";
+        $commandHandler     = $this->container->get($commandHandlerName);
 
         assert(is_callable($commandHandler), 'Make sure your command handler is callable');
 

--- a/test/Asset/TestCommand.php
+++ b/test/Asset/TestCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZfrCommandBusTest\Asset;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class TestCommand
+{
+}

--- a/test/Asset/TestCommandHandler.php
+++ b/test/Asset/TestCommandHandler.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ZfrCommandBusTest\Asset;
+
+/**
+ * @author Daniel Gimenes
+ */
+final class TestCommandHandler
+{
+    public function __invoke(TestCommand $command): void
+    {
+    }
+}

--- a/test/Container/SimpleCommandBusFactoryTest.php
+++ b/test/Container/SimpleCommandBusFactoryTest.php
@@ -4,18 +4,15 @@ namespace ZfrCommandBusTest\Container;
 
 use Interop\Container\ContainerInterface;
 use ZfrCommandBus\Container\SimpleCommandBusFactory;
-use ZfrCommandBus\Exception\OutOfBoundsException;
 
 class SimpleCommandBusFactoryTest extends \PHPUnit_Framework_TestCase
 {
-    public function testThrowsExceptionIfMissingConfigKey()
+    public function testUsesEmptyHandlerMapByDefault()
     {
         $container = $this->prophesize(ContainerInterface::class);
         $factory   = new SimpleCommandBusFactory();
 
         $container->get('config')->shouldBeCalled()->willReturn([]);
-
-        $this->setExpectedException(OutOfBoundsException::class);
 
         $factory($container->reveal());
     }


### PR DESCRIPTION
We can still map `Command => CommandHandler` in config, but in case it is not registered, the command bus will automatically try to guess the command handler name by adding the "Handler" suffix.